### PR TITLE
Dev json setup

### DIFF
--- a/src/TeleScope.MSTest/Mockups/IMockable.cs
+++ b/src/TeleScope.MSTest/Mockups/IMockable.cs
@@ -1,0 +1,8 @@
+﻿namespace TeleScope.MSTest.Mockups
+{
+	interface IMockable
+	{
+		int Id { get; set; }
+		string Name { get; set; }
+	}
+}

--- a/src/TeleScope.MSTest/Mockups/Mockup.cs
+++ b/src/TeleScope.MSTest/Mockups/Mockup.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace TeleScope.MSTest.Mockups
 {
-	public class Mockup
+	public class Mockup : IMockable
 	{
 		// -- static fields
 
@@ -36,6 +36,7 @@ namespace TeleScope.MSTest.Mockups
 
 		public Mockup()
 		{
+			Name = this.GetType().Name;
 			Greetings = "Hello Mockup";
 			Timestamp = DateTime.Now;
 		}

--- a/src/TeleScope.MSTest/Mockups/MockupRepository.cs
+++ b/src/TeleScope.MSTest/Mockups/MockupRepository.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TeleScope.MSTest.Mockups
+{
+	internal class MockupRepository
+	{
+		public List<IMockable> Mockups { get; set; }
+
+		public MockupRepository()
+		{
+			Mockups = new List<IMockable>();
+		}
+	}
+}

--- a/src/TeleScope.MSTest/Persistence/PersistenceTests.cs
+++ b/src/TeleScope.MSTest/Persistence/PersistenceTests.cs
@@ -1,12 +1,17 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using TeleScope.Logging.Extensions;
 using TeleScope.MSTest.Mockups;
 using TeleScope.MSTest.Persistence.Attributes;
 using TeleScope.Persistence.Abstractions;
+using TeleScope.Persistence.Json;
+using TeleScope.Persistence.Json.Extensions;
 using TeleScope.Persistence.Yaml;
 
 namespace TeleScope.MSTest.Persistence
@@ -68,6 +73,45 @@ namespace TeleScope.MSTest.Persistence
 			// assert
 			Assert.IsTrue(File.Exists(file), "File creation failed.");
 			Assert.IsTrue(File.ReadAllBytes(file).Length > 0, "File should not be empty.");
+		}
+
+		[TestMethod]
+		public void WriteAndReadGenericTypes()
+		{
+			// -- arrange
+
+			var data = new MockupRepository();
+			data.Mockups.AddRange(Mockup.RandomArray(3));
+
+			var filename = "generic.json";
+			file = Path.Combine(APP_FOLDER, filename);
+			var fileinfo = new FileInfo(file);
+
+			var newtonsoftsettings = new JsonSerializerSettings();
+			newtonsoftsettings.Converters.Add(new StringEnumConverter());
+			newtonsoftsettings.KnownTypes(new List<Type>()
+			{
+				typeof(Mockup)
+			});
+
+			var json = new JsonStorage<MockupRepository>(
+				new JsonStorageSetup(fileinfo, true, true),
+				newtonsoftsettings);
+
+			// -- act & assert: write
+
+			json.Write(new MockupRepository[] { data });
+			Assert.IsTrue(fileinfo.Exists, $"The file '{filename}' should has been created.");
+
+			// -- act & assert: read
+
+			var import = json.Read().First();
+
+			Assert.IsNotNull(import, "The json import should not be null.");
+			import.Mockups.ForEach(m => {
+				Assert.IsNotNull(m, "The element should not be null");
+				Assert.IsFalse(string.IsNullOrEmpty(m.Name), "The name of the element should not be null or empty");
+			});
 		}
 
 		[TestMethod]
@@ -143,6 +187,19 @@ namespace TeleScope.MSTest.Persistence
 					Assert.IsTrue(File.Exists(source), $"The source '{source}' should NOT have been deleted.");
 				}
 			}
+		}
+
+
+
+	}
+
+	class MockupRepository
+	{
+		public List<IMockable> Mockups { get; set; }
+
+		public MockupRepository()
+		{
+			Mockups = new List<IMockable>();
 		}
 	}
 }

--- a/src/TeleScope.MSTest/Persistence/PersistenceTests.cs
+++ b/src/TeleScope.MSTest/Persistence/PersistenceTests.cs
@@ -192,14 +192,4 @@ namespace TeleScope.MSTest.Persistence
 
 
 	}
-
-	class MockupRepository
-	{
-		public List<IMockable> Mockups { get; set; }
-
-		public MockupRepository()
-		{
-			Mockups = new List<IMockable>();
-		}
-	}
 }

--- a/src/TeleScope.MSTest/TestsBase.cs
+++ b/src/TeleScope.MSTest/TestsBase.cs
@@ -12,6 +12,9 @@ namespace TeleScope.MSTest
 	{
 
 		// -- fields
+
+		public const string APP_FOLDER = "App_Data";
+
 		private Stopwatch watch;
 		protected ILogger log;
 		protected const string SKIP_PLC_TESTS = "SkipPlcTests";

--- a/src/TeleScope.Persistence.Json/Binder/KnownTypesBinder.cs
+++ b/src/TeleScope.Persistence.Json/Binder/KnownTypesBinder.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace TeleScope.Persistence.Json.Binder
+{
+	public class KnownTypesBinder : ISerializationBinder
+	{
+		// -- properties
+
+		public IEnumerable<Type> KnownTypes { get; set; }
+
+		// -- constructor
+
+		public KnownTypesBinder()
+		{
+			KnownTypes = new List<Type>();
+
+		}
+
+		public KnownTypesBinder(IEnumerable<Type> types)
+		{
+			KnownTypes = types;
+		}
+
+		// -- methods
+
+		public Type BindToType(string assemblyName, string typeName)
+		{
+			return KnownTypes.SingleOrDefault(t => t.Name == typeName);
+		}
+
+		public void BindToName(Type serializedType, out string assemblyName, out string typeName)
+		{
+			assemblyName = null;
+			typeName = serializedType.Name;
+		}
+	}
+}

--- a/src/TeleScope.Persistence.Json/Binder/KnownTypesBinder.cs
+++ b/src/TeleScope.Persistence.Json/Binder/KnownTypesBinder.cs
@@ -5,32 +5,49 @@ using Newtonsoft.Json.Serialization;
 
 namespace TeleScope.Persistence.Json.Binder
 {
+	/// <summary>
+	/// This class collects <seealso cref="Type"/> objects in order to include their names intor the 
+	/// de- and serialization process of Newtonsoft.Json.
+	/// For more information, see [custom SerializationBinder](https://www.newtonsoft.com/json/help/html/SerializeSerializationBinder.htm).
+	/// </summary>
 	public class KnownTypesBinder : ISerializationBinder
 	{
-		// -- properties
+		// -- fields
 
-		public IEnumerable<Type> KnownTypes { get; set; }
+		private readonly IEnumerable<Type> knownTypes;
 
 		// -- constructor
 
-		public KnownTypesBinder()
-		{
-			KnownTypes = new List<Type>();
-
-		}
-
+		/// <summary>
+		/// The default constructor takes all known types as input parameter stores them internally.
+		/// </summary>
+		/// <param name="types">The enumeration of known types.</param>
 		public KnownTypesBinder(IEnumerable<Type> types)
 		{
-			KnownTypes = types;
+			knownTypes = types;
 		}
 
 		// -- methods
 
+		/// <summary>
+		/// Controls the binding of a serialized object to a type.
+		/// See [ISerializationBinder](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_Serialization_ISerializationBinder.htm).
+		/// </summary>
+		/// <param name="assemblyName">Specifies the Assembly name of the serialized object.</param>
+		/// <param name="typeName">Specifies the Type name of the serialized object.</param>
+		/// <returns></returns>
 		public Type BindToType(string assemblyName, string typeName)
 		{
-			return KnownTypes.SingleOrDefault(t => t.Name == typeName);
+			return knownTypes.SingleOrDefault(t => t.Name == typeName);
 		}
 
+		/// <summary>
+		/// Controls the binding of a serialized object to a type.
+		/// See [ISerializationBinder](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_Serialization_ISerializationBinder.htm).
+		/// </summary>
+		/// <param name="serializedType">The type of the object the formatter creates a new instance of.</param>
+		/// <param name="assemblyName">Specifies the Assembly name of the serialized object.</param>
+		/// <param name="typeName">Specifies the Type name of the serialized object.</param>
 		public void BindToName(Type serializedType, out string assemblyName, out string typeName)
 		{
 			assemblyName = null;

--- a/src/TeleScope.Persistence.Json/Extensions/JsonSerializerSettingExtensions.cs
+++ b/src/TeleScope.Persistence.Json/Extensions/JsonSerializerSettingExtensions.cs
@@ -5,8 +5,17 @@ using TeleScope.Persistence.Json.Binder;
 
 namespace TeleScope.Persistence.Json.Extensions
 {
+	/// <summary>
+	/// The extension class enables a simplified binding of concrete types 
+	/// to the `Newtonsoft.Json` de- and serialization process.
+	/// </summary>
 	public static class JsonSerializerSettingExtensions
 	{
+		/// <summary>
+		/// Binds an enumerartion of `Type` to the calling instance of <seealso cref="JsonSerializerSettings"/>.
+		/// </summary>
+		/// <param name="settings">The calling instance.</param>
+		/// <param name="types">The types that need to be known by the de- and serialization process.</param>
 		public static void KnownTypes(this JsonSerializerSettings settings, IEnumerable<Type> types)
 		{
 			var binder = new KnownTypesBinder(types);

--- a/src/TeleScope.Persistence.Json/Extensions/JsonSerializerSettingExtensions.cs
+++ b/src/TeleScope.Persistence.Json/Extensions/JsonSerializerSettingExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using TeleScope.Persistence.Json.Binder;
+
+namespace TeleScope.Persistence.Json.Extensions
+{
+	public static class JsonSerializerSettingExtensions
+	{
+		public static void KnownTypes(this JsonSerializerSettings settings, IEnumerable<Type> types)
+		{
+			var binder = new KnownTypesBinder(types);
+			settings.SerializationBinder = binder;
+			settings.TypeNameHandling = TypeNameHandling.Auto;
+		}
+	}
+}

--- a/src/TeleScope.Persistence.Json/JsonStorage.cs
+++ b/src/TeleScope.Persistence.Json/JsonStorage.cs
@@ -51,6 +51,7 @@ namespace TeleScope.Persistence.Json
 			this.setup = setup ?? throw new ArgumentNullException(nameof(setup));
 			log = LoggingProvider.CreateLogger<JsonStorage<T>>();
 			settings = new JsonSerializerSettings();
+			settings.Converters.Add(new StringEnumConverter());
 		}
 
 		/// <summary>
@@ -78,7 +79,7 @@ namespace TeleScope.Persistence.Json
 			using (StreamReader r = new StreamReader(setup.File))
 			{
 				string input = r.ReadToEnd();
-				result = JsonConvert.DeserializeObject<T>(input);
+				result = JsonConvert.DeserializeObject<T>(input, settings);
 			}
 
 			log.Trace("Reading json successfull from {0}", setup.File);

--- a/src/TeleScope.Persistence.Json/JsonStorage.cs
+++ b/src/TeleScope.Persistence.Json/JsonStorage.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using TeleScope.Logging;
 using TeleScope.Logging.Extensions;
 using TeleScope.Persistence.Abstractions;

--- a/src/TeleScope.Persistence.Json/JsonStorageSetup.cs
+++ b/src/TeleScope.Persistence.Json/JsonStorageSetup.cs
@@ -27,6 +27,7 @@ namespace TeleScope.Persistence.Json
 		/// <summary>
 		/// The default constructor calls the constructor of the base class and 
 		/// defines `UTF8` as default <seealso cref="Encoder"/> property.
+		/// </summary>
 		/// <param name="fileInfo">The information about the file that will get accessed by a file storage.</param>
 		/// <param name="canCreate">Sets the information, if the setup provides the ability to create files.</param>
 		/// <param name="canDelete">Sets the information, if the setup provides the ability to delete files.</param>

--- a/src/TeleScope.Persistence.Json/JsonStorageSetup.cs
+++ b/src/TeleScope.Persistence.Json/JsonStorageSetup.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
 using TeleScope.Persistence.Abstractions;
 
@@ -10,6 +13,10 @@ namespace TeleScope.Persistence.Json
 	/// </summary>
 	public class JsonStorageSetup : FileSetupBase
 	{
+		// -- fields
+
+		private readonly List<Type> typeConversions;
+
 		// -- properties
 
 		/// <summary>
@@ -17,21 +24,33 @@ namespace TeleScope.Persistence.Json
 		/// </summary>
 		public Encoding Encoder { get; set; }
 
+		/// <summary>
+		/// Gets or sets the behaviour to convert enums automatically into strings. The default value is `True`.
+		/// </summary>
+		public bool ConvertEnumToString { get; set; }
+
+		/// <summary>
+		/// Gets the defined types that are used to convet base classes or interfaces into concrete types.
+		/// </summary>
+		public IEnumerable<Type> TypeConversions { get; }
+
 		// -- constructor
 
 		/// <summary>
 		/// The default constructor calls the constructor of the base class and 
 		/// defines `UTF8` as default <seealso cref="Encoder"/> property.
-		/// </summary>
 		/// <param name="fileInfo">The information about the file that will get accessed by a file storage.</param>
 		/// <param name="canCreate">Sets the information, if the setup provides the ability to create files.</param>
 		/// <param name="canDelete">Sets the information, if the setup provides the ability to delete files.</param>
+		/// <param name="typeConversions"></param>
 		public JsonStorageSetup(
 			FileInfo fileInfo,
 			bool canCreate = true,
-			bool canDelete = true) : base(fileInfo, canCreate, canDelete)
+			bool canDelete = true, IEnumerable<Type> typeConversions = null) : base(fileInfo, canCreate, canDelete)
 		{
 			Encoder = Encoding.UTF8;
+			ConvertEnumToString = true;
+			this.typeConversions = typeConversions?.ToList() ?? new List<Type>();
 		}
 	}
 }

--- a/src/TeleScope.Persistence.Json/JsonStorageSetup.cs
+++ b/src/TeleScope.Persistence.Json/JsonStorageSetup.cs
@@ -15,24 +15,12 @@ namespace TeleScope.Persistence.Json
 	{
 		// -- fields
 
-		private readonly List<Type> typeConversions;
-
 		// -- properties
 
 		/// <summary>
 		/// Gets or sets the encoding of the file.
 		/// </summary>
 		public Encoding Encoder { get; set; }
-
-		/// <summary>
-		/// Gets or sets the behaviour to convert enums automatically into strings. The default value is `True`.
-		/// </summary>
-		public bool ConvertEnumToString { get; set; }
-
-		/// <summary>
-		/// Gets the defined types that are used to convet base classes or interfaces into concrete types.
-		/// </summary>
-		public IEnumerable<Type> TypeConversions { get; }
 
 		// -- constructor
 
@@ -42,15 +30,12 @@ namespace TeleScope.Persistence.Json
 		/// <param name="fileInfo">The information about the file that will get accessed by a file storage.</param>
 		/// <param name="canCreate">Sets the information, if the setup provides the ability to create files.</param>
 		/// <param name="canDelete">Sets the information, if the setup provides the ability to delete files.</param>
-		/// <param name="typeConversions"></param>
 		public JsonStorageSetup(
 			FileInfo fileInfo,
 			bool canCreate = true,
-			bool canDelete = true, IEnumerable<Type> typeConversions = null) : base(fileInfo, canCreate, canDelete)
+			bool canDelete = true) : base(fileInfo, canCreate, canDelete)
 		{
 			Encoder = Encoding.UTF8;
-			ConvertEnumToString = true;
-			this.typeConversions = typeConversions?.ToList() ?? new List<Type>();
 		}
 	}
 }

--- a/src/TeleScope.Persistence.Json/TeleScope.Persistence.Json.csproj
+++ b/src/TeleScope.Persistence.Json/TeleScope.Persistence.Json.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>TeleScope-dotnet members</Authors>
     <Company>TeleScope-dotnet</Company>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/TeleScope.Persistence.Json/TeleScope.Persistence.Json.xml
+++ b/src/TeleScope.Persistence.Json/TeleScope.Persistence.Json.xml
@@ -4,6 +4,50 @@
         <name>TeleScope.Persistence.Json</name>
     </assembly>
     <members>
+        <member name="T:TeleScope.Persistence.Json.Binder.KnownTypesBinder">
+            <summary>
+            This class collects <seealso cref="T:System.Type"/> objects in order to include their names intor the 
+            de- and serialization process of Newtonsoft.Json.
+            For more information, see [custom SerializationBinder](https://www.newtonsoft.com/json/help/html/SerializeSerializationBinder.htm).
+            </summary>
+        </member>
+        <member name="M:TeleScope.Persistence.Json.Binder.KnownTypesBinder.#ctor(System.Collections.Generic.IEnumerable{System.Type})">
+            <summary>
+            The default constructor takes all known types as input parameter stores them internally.
+            </summary>
+            <param name="types">The enumeration of known types.</param>
+        </member>
+        <member name="M:TeleScope.Persistence.Json.Binder.KnownTypesBinder.BindToType(System.String,System.String)">
+            <summary>
+            Controls the binding of a serialized object to a type.
+            See [ISerializationBinder](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_Serialization_ISerializationBinder.htm).
+            </summary>
+            <param name="assemblyName">Specifies the Assembly name of the serialized object.</param>
+            <param name="typeName">Specifies the Type name of the serialized object.</param>
+            <returns></returns>
+        </member>
+        <member name="M:TeleScope.Persistence.Json.Binder.KnownTypesBinder.BindToName(System.Type,System.String@,System.String@)">
+            <summary>
+            Controls the binding of a serialized object to a type.
+            See [ISerializationBinder](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_Serialization_ISerializationBinder.htm).
+            </summary>
+            <param name="serializedType">The type of the object the formatter creates a new instance of.</param>
+            <param name="assemblyName">Specifies the Assembly name of the serialized object.</param>
+            <param name="typeName">Specifies the Type name of the serialized object.</param>
+        </member>
+        <member name="T:TeleScope.Persistence.Json.Extensions.JsonSerializerSettingExtensions">
+            <summary>
+            The extension class enables a simplified binding of concrete types 
+            to the `Newtonsoft.Json` de- and serialization process.
+            </summary>
+        </member>
+        <member name="M:TeleScope.Persistence.Json.Extensions.JsonSerializerSettingExtensions.KnownTypes(Newtonsoft.Json.JsonSerializerSettings,System.Collections.Generic.IEnumerable{System.Type})">
+            <summary>
+            Binds an enumerartion of `Type` to the calling instance of <seealso cref="T:Newtonsoft.Json.JsonSerializerSettings"/>.
+            </summary>
+            <param name="settings">The calling instance.</param>
+            <param name="types">The types that need to be known by the de- and serialization process.</param>
+        </member>
         <member name="T:TeleScope.Persistence.Json.JsonStorage`1">
             <summary>
             This class provides access to JSON files and parses the data into the application-side type T.
@@ -65,6 +109,14 @@
             Gets or sets the encoding of the file.
             </summary>
         </member>
-        <!-- Badly formed XML comment ignored for member "M:TeleScope.Persistence.Json.JsonStorageSetup.#ctor(System.IO.FileInfo,System.Boolean,System.Boolean)" -->
+        <member name="M:TeleScope.Persistence.Json.JsonStorageSetup.#ctor(System.IO.FileInfo,System.Boolean,System.Boolean)">
+            <summary>
+            The default constructor calls the constructor of the base class and 
+            defines `UTF8` as default <seealso cref="P:TeleScope.Persistence.Json.JsonStorageSetup.Encoder"/> property.
+            </summary>
+            <param name="fileInfo">The information about the file that will get accessed by a file storage.</param>
+            <param name="canCreate">Sets the information, if the setup provides the ability to create files.</param>
+            <param name="canDelete">Sets the information, if the setup provides the ability to delete files.</param>
+        </member>
     </members>
 </doc>

--- a/src/TeleScope.Persistence.Json/TeleScope.Persistence.Json.xml
+++ b/src/TeleScope.Persistence.Json/TeleScope.Persistence.Json.xml
@@ -65,14 +65,6 @@
             Gets or sets the encoding of the file.
             </summary>
         </member>
-        <member name="M:TeleScope.Persistence.Json.JsonStorageSetup.#ctor(System.IO.FileInfo,System.Boolean,System.Boolean)">
-            <summary>
-            The default constructor calls the constructor of the base class and 
-            defines `UTF8` as default <seealso cref="P:TeleScope.Persistence.Json.JsonStorageSetup.Encoder"/> property.
-            </summary>
-            <param name="fileInfo">The information about the file that will get accessed by a file storage.</param>
-            <param name="canCreate">Sets the information, if the setup provides the ability to create files.</param>
-            <param name="canDelete">Sets the information, if the setup provides the ability to delete files.</param>
-        </member>
+        <!-- Badly formed XML comment ignored for member "M:TeleScope.Persistence.Json.JsonStorageSetup.#ctor(System.IO.FileInfo,System.Boolean,System.Boolean)" -->
     </members>
 </doc>


### PR DESCRIPTION
Hi @tripoder, 

I hope this MR finds you well. 

I have updated the Persistence.Json implementation a little bit, in order to achieve an easy-to-use binding of types that are provided in interfaces. The API of the JsonStorage was not changed. Instead the JsonSerializerSettings has now an extension method to bind new types. 

You can find a compact view of the client-API in the unit test [WriteAndReadGenericTypes](https://github.com/telescope-dotnet/telescope/blob/dev-json-setup/src/TeleScope.MSTest/Persistence/PersistenceTests.cs#L79).

Best regards, 🤓 