### PR TITLE
dev-smtp-setup into main

### DIFF
--- a/src/TeleScope.Connectors.Abstractions/Secrets/Secret.cs
+++ b/src/TeleScope.Connectors.Abstractions/Secrets/Secret.cs
@@ -3,7 +3,7 @@
 namespace TeleScope.Connectors.Abstractions.Secrets
 {
 	/// <summary>
-	/// Implements the `ISecret` interface to encapsulate a names and passwords within this type.
+	/// Implements the <seealso cref="ISecret"/> interface to encapsulate a name and a password within this type.
 	/// </summary>
 	public class Secret : ISecret
 	{

--- a/src/TeleScope.Connectors.Abstractions/TeleScope.Connectors.Abstractions.xml
+++ b/src/TeleScope.Connectors.Abstractions/TeleScope.Connectors.Abstractions.xml
@@ -183,7 +183,7 @@
         </member>
         <member name="T:TeleScope.Connectors.Abstractions.Secrets.Secret">
             <summary>
-            Implements the `ISecret` interface to encapsulate a names and passwords within this type.
+            Implements the <seealso cref="T:TeleScope.Connectors.Abstractions.Secrets.ISecret"/> interface to encapsulate a name and a password within this type.
             </summary>
         </member>
         <member name="P:TeleScope.Connectors.Abstractions.Secrets.Secret.Name">

--- a/src/TeleScope.Connectors.Smtp.Abstractions/ISmtpConnectable.cs
+++ b/src/TeleScope.Connectors.Smtp.Abstractions/ISmtpConnectable.cs
@@ -14,6 +14,16 @@ namespace TeleScope.Connectors.Smtp.Abstractions
 
 		/// <summary>
 		/// This method should add a new message to an internal collection 
+		/// with only specific properties, needed to build a new email object. 
+		/// Sender and receivers should be known by the implementing instace beforehand.
+		/// </summary>
+		/// <param name="subject">The subject of the email.</param>
+		/// <param name="body">The message of the email.</param>
+		/// <returns>Returns the calling instance to enable chaining method calls.</returns>
+		ISmtpConnectable NewMessage(string subject, string body);
+
+		/// <summary>
+		/// This method should add a new message to an internal collection 
 		/// with the essetial properties, needed to build a new email object.
 		/// </summary>
 		/// <param name="from">The email address of the sender.</param>

--- a/src/TeleScope.Connectors.Smtp.Abstractions/TeleScope.Connectors.Smtp.Abstractions.xml
+++ b/src/TeleScope.Connectors.Smtp.Abstractions/TeleScope.Connectors.Smtp.Abstractions.xml
@@ -10,6 +10,16 @@
             It supprots SMTP connections to send emails with a minimal interface. 
             </summary>
         </member>
+        <member name="M:TeleScope.Connectors.Smtp.Abstractions.ISmtpConnectable.NewMessage(System.String,System.String)">
+            <summary>
+            This method should add a new message to an internal collection 
+            with only specific properties, needed to build a new email object. 
+            Sender and receivers should be known by the implementing instace beforehand.
+            </summary>
+            <param name="subject">The subject of the email.</param>
+            <param name="body">The message of the email.</param>
+            <returns>Returns the calling instance to enable chaining method calls.</returns>
+        </member>
         <member name="M:TeleScope.Connectors.Smtp.Abstractions.ISmtpConnectable.NewMessage(System.String,System.String,System.String,System.String)">
             <summary>
             This method should add a new message to an internal collection 

--- a/src/TeleScope.Connectors.Smtp/SmtpSetup.cs
+++ b/src/TeleScope.Connectors.Smtp/SmtpSetup.cs
@@ -1,0 +1,64 @@
+﻿using TeleScope.Connectors.Abstractions.Secrets;
+
+namespace TeleScope.Connectors.Smtp
+{
+	/// <summary>
+	/// This class encapsulates the settings for the <seealso cref="SmtpConnector"/> type.
+	/// </summary>
+	public class SmtpSetup
+	{
+		/// <summary>
+		/// The default retry limit is `3` for attempts to send messages via Smtp.
+		/// </summary>
+		public const int RETRY_LIMIT = 3;
+
+		// -- properties
+
+		/// <summary>
+		/// Gets or sets the host for the smtp connection.
+		/// </summary>
+		public string Host { get; set; }
+
+		/// <summary>
+		/// Gets or set the sending email address.
+		/// </summary>
+		public string Sender { get; set; }
+
+		/// <summary>
+		/// Gets or sets the port for the smtp connection.
+		/// 
+		/// **Please note the default ports:**
+		/// * Port 25 (non-secure) - this is the default port (often times blocked by your ISP - Internet Service Provider)
+		/// * Port 26 (non-secure) - use port 26 if port 25 is not working and is blocked by your ISP
+		/// * Port 465 (secure - SSL) - this is to be used to send email via SMTP securely over SSL
+		/// * Port 587 (secure - TLS) - this is to be used to send email via SMTP securely over TLS
+		/// </summary>
+		public int Port { get; set; }
+
+		/// <summary>
+		/// Gets or sets all receivers that are addressed by sending an email.
+		/// </summary>
+		public string[] Receivers { get; set; }
+
+		/// <summary>
+		/// Gets or sets the connection information (e.g. name and passwort) of type <seealso cref="ISecret"/>.
+		/// </summary>
+		public ISecret Credentials { get; set; }
+
+		/// <summary>
+		/// Gets or sets the limit of retry attempts for sending an email.
+		/// The default retry limit is `3`.
+		/// </summary>
+		public int RetryLimit { get; set; }
+
+		// -- constructor
+
+		/// <summary>
+		/// The default empty constructor sets the retry limit to its default value.
+		/// </summary>
+		public SmtpSetup()
+		{
+			RetryLimit = RETRY_LIMIT;
+		}
+	}
+}

--- a/src/TeleScope.Connectors.Smtp/SmtpSetup.cs
+++ b/src/TeleScope.Connectors.Smtp/SmtpSetup.cs
@@ -7,11 +7,6 @@ namespace TeleScope.Connectors.Smtp
 	/// </summary>
 	public class SmtpSetup
 	{
-		/// <summary>
-		/// The default retry limit is `3` for attempts to send messages via Smtp.
-		/// </summary>
-		public const int RETRY_LIMIT = 3;
-
 		// -- properties
 
 		/// <summary>
@@ -45,12 +40,6 @@ namespace TeleScope.Connectors.Smtp
 		/// </summary>
 		public ISecret Credentials { get; set; }
 
-		/// <summary>
-		/// Gets or sets the limit of retry attempts for sending an email.
-		/// The default retry limit is `3`.
-		/// </summary>
-		public int RetryLimit { get; set; }
-
 		// -- constructor
 
 		/// <summary>
@@ -58,7 +47,7 @@ namespace TeleScope.Connectors.Smtp
 		/// </summary>
 		public SmtpSetup()
 		{
-			RetryLimit = RETRY_LIMIT;
+
 		}
 	}
 }

--- a/src/TeleScope.Connectors.Smtp/TeleScope.Connectors.Smtp.csproj
+++ b/src/TeleScope.Connectors.Smtp/TeleScope.Connectors.Smtp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-	<Version>1.0.0</Version>
+	<Version>1.1.0</Version>
     <Authors>TeleScope-dotnet members</Authors>
     <Company>TeleScope-dotnet</Company>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/TeleScope.Connectors.Smtp/TeleScope.Connectors.Smtp.csproj
+++ b/src/TeleScope.Connectors.Smtp/TeleScope.Connectors.Smtp.csproj
@@ -33,4 +33,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/TeleScope.Connectors.Smtp/TeleScope.Connectors.Smtp.xml
+++ b/src/TeleScope.Connectors.Smtp/TeleScope.Connectors.Smtp.xml
@@ -41,14 +41,13 @@
             </summary>
             <param name="setup">The setup that is used for the smtp connections.</param>
         </member>
-        <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.#ctor(System.String,System.Int32,TeleScope.Connectors.Abstractions.Secrets.ISecret,System.Int32)">
+        <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.#ctor(System.String,System.Int32,TeleScope.Connectors.Abstractions.Secrets.ISecret)">
             <summary>
             The constructor gets the SMTP host configuration injected.
             </summary>
             <param name="host">The name of the host or server.</param>
             <param name="port">The port where the SMTP protocol is accessible at the host.</param>
             <param name="secret">The user credentials to get access at the host.</param>
-            <param name="retry">The number of retries if sending returns an error. The default value is `3`.</param>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.Connect">
             <summary>
@@ -172,11 +171,6 @@
             This class encapsulates the settings for the <seealso cref="T:TeleScope.Connectors.Smtp.SmtpConnector"/> type.
             </summary>
         </member>
-        <member name="F:TeleScope.Connectors.Smtp.SmtpSetup.RETRY_LIMIT">
-            <summary>
-            The default retry limit is `3` for attempts to send messages via Smtp.
-            </summary>
-        </member>
         <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.Host">
             <summary>
             Gets or sets the host for the smtp connection.
@@ -206,12 +200,6 @@
         <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.Credentials">
             <summary>
             Gets or sets the connection information (e.g. name and passwort) of type <seealso cref="T:TeleScope.Connectors.Abstractions.Secrets.ISecret"/>.
-            </summary>
-        </member>
-        <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.RetryLimit">
-            <summary>
-            Gets or sets the limit of retry attempts for sending an email.
-            The default retry limit is `3`.
             </summary>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpSetup.#ctor">

--- a/src/TeleScope.Connectors.Smtp/TeleScope.Connectors.Smtp.xml
+++ b/src/TeleScope.Connectors.Smtp/TeleScope.Connectors.Smtp.xml
@@ -35,9 +35,15 @@
             The event is invoked when the <seealso cref="M:TeleScope.Connectors.Smtp.SmtpConnector.Send"/> method has finished with a failure.
             </summary>
         </member>
+        <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.#ctor(TeleScope.Connectors.Smtp.SmtpSetup)">
+            <summary>
+            The default constructor stores the setup and starts the internal logging mechanism. 
+            </summary>
+            <param name="setup">The setup that is used for the smtp connections.</param>
+        </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.#ctor(System.String,System.Int32,TeleScope.Connectors.Abstractions.Secrets.ISecret,System.Int32)">
             <summary>
-            The default constructor gets the SMTP host configuration injected.
+            The constructor gets the SMTP host configuration injected.
             </summary>
             <param name="host">The name of the host or server.</param>
             <param name="port">The port where the SMTP protocol is accessible at the host.</param>
@@ -58,6 +64,18 @@
             </summary>
             <returns>The calling instance.</returns>
         </member>
+        <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.NewMessage(System.String,System.String)">
+            <summary>
+            Adds a new message to an internal collection of emails
+            with only specific properties, needed to build a new email object. 
+            Sender and receivers are known by the implementing instace beforehand.
+            </summary>
+            <param name="subject">The subject of the email.</param>
+            <param name="body">The message of the email.</param>
+            <returns>Returns the calling instance to enable chaining method calls.</returns>
+            <exception cref="T:System.ArgumentNullException">Is thrown when the body is null.</exception>
+            <exception cref="T:System.ArgumentException">Is thrown when any email address has an invalid format.</exception>
+        </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.NewMessage(System.String,System.String,System.String,System.String)">
             <summary>
             Adds a new message to an internal collection of emails
@@ -68,6 +86,8 @@
             <param name="subject">The subject of the email.</param>
             <param name="body">The message of the email.</param>
             <returns>Returns the calling instance to enable chaining method calls.</returns>
+            <exception cref="T:System.ArgumentNullException">Is thrown when the body is null.</exception>
+            <exception cref="T:System.ArgumentException">Is thrown when any email address has an invalid format.</exception>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.NewMessage(System.String,System.String[],System.String,System.String)">
             <summary>
@@ -79,6 +99,8 @@
             <param name="subject">The subject of the email.</param>
             <param name="body">The message of the email.</param>
             <returns>Returns the calling instance to enable chaining method calls.</returns>
+            <exception cref="T:System.ArgumentNullException">Is thrown when the body is null.</exception>
+            <exception cref="T:System.ArgumentException">Is thrown when any email address has an invalid format.</exception>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.CarbonCopy(System.String)">
             <summary>
@@ -87,6 +109,7 @@
             </summary>
             <param name="to">The email address of the receiver.</param>
             <returns>Returns the calling instance to enable chaining method calls.</returns>
+            <exception cref="T:System.ArgumentException">Is thrown when any email address has an invalid format.</exception>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.CarbonCopy(System.String[])">
             <summary>
@@ -95,6 +118,7 @@
             </summary>
             <param name="to">The email addresses of the receivers.</param>
             <returns>Returns the calling instance to enable chaining method calls.</returns>
+            <exception cref="T:System.ArgumentException">Is thrown when any email address has an invalid format.</exception>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.BlindCarbonCopy(System.String)">
             <summary>
@@ -103,6 +127,7 @@
             </summary>
             <param name="to">The email address of the receiver.</param>
             <returns>Returns the calling instance to enable chaining method calls.</returns>
+            <exception cref="T:System.ArgumentException">Is thrown when any email address has an invalid format.</exception>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.BlindCarbonCopy(System.String[])">
             <summary>
@@ -111,6 +136,7 @@
             </summary>
             <param name="to">The email addresses of the receivers.</param>
             <returns>Returns the calling instance to enable chaining method calls.</returns>
+            <exception cref="T:System.ArgumentException">Is thrown when any email address has an invalid format.</exception>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.HighPriority">
             <summary>
@@ -131,6 +157,7 @@
             <param name="file">The file info object that will be attached.</param>
             <param name="mimeType">The mime type of the file.</param>
             <returns>Returns the calling instance to enable chaining method calls.</returns>
+            <exception cref="T:System.ArgumentNullException">Is thrown when the attachment is not found or valid.</exception>
         </member>
         <member name="M:TeleScope.Connectors.Smtp.SmtpConnector.Send">
             <summary>
@@ -139,6 +166,58 @@
             </summary>
             <returns>Returns a result triple that contains the total amount of sent emails, 
             the sucessful and the failed ones.</returns>
+        </member>
+        <member name="T:TeleScope.Connectors.Smtp.SmtpSetup">
+            <summary>
+            This class encapsulates the settings for the <seealso cref="T:TeleScope.Connectors.Smtp.SmtpConnector"/> type.
+            </summary>
+        </member>
+        <member name="F:TeleScope.Connectors.Smtp.SmtpSetup.RETRY_LIMIT">
+            <summary>
+            The default retry limit is `3` for attempts to send messages via Smtp.
+            </summary>
+        </member>
+        <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.Host">
+            <summary>
+            Gets or sets the host for the smtp connection.
+            </summary>
+        </member>
+        <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.Sender">
+            <summary>
+            Gets or set the sending email address.
+            </summary>
+        </member>
+        <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.Port">
+            <summary>
+            Gets or sets the port for the smtp connection.
+            
+            **Please note the default ports:**
+            * Port 25 (non-secure) - this is the default port (often times blocked by your ISP - Internet Service Provider)
+            * Port 26 (non-secure) - use port 26 if port 25 is not working and is blocked by your ISP
+            * Port 465 (secure - SSL) - this is to be used to send email via SMTP securely over SSL
+            * Port 587 (secure - TLS) - this is to be used to send email via SMTP securely over TLS
+            </summary>
+        </member>
+        <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.Receivers">
+            <summary>
+            Gets or sets all receivers that are addressed by sending an email.
+            </summary>
+        </member>
+        <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.Credentials">
+            <summary>
+            Gets or sets the connection information (e.g. name and passwort) of type <seealso cref="T:TeleScope.Connectors.Abstractions.Secrets.ISecret"/>.
+            </summary>
+        </member>
+        <member name="P:TeleScope.Connectors.Smtp.SmtpSetup.RetryLimit">
+            <summary>
+            Gets or sets the limit of retry attempts for sending an email.
+            The default retry limit is `3`.
+            </summary>
+        </member>
+        <member name="M:TeleScope.Connectors.Smtp.SmtpSetup.#ctor">
+            <summary>
+            The default empty constructor sets the retry limit to its default value.
+            </summary>
         </member>
     </members>
 </doc>

--- a/src/TeleScope.MSTest/Infrastructure/SmtpTests.cs
+++ b/src/TeleScope.MSTest/Infrastructure/SmtpTests.cs
@@ -52,7 +52,7 @@ namespace TeleScope.MSTest.Infrastructure
 			}
 
 			// arrange
-			var address = "";
+			var address = "your.email@awesome.com";
 			var copy = "";
 			var password = "";
 			var credentials = new Secret(address, password);
@@ -64,12 +64,19 @@ namespace TeleScope.MSTest.Infrastructure
 			var subject = $"Greetings from {this.GetType().FullName}";
 			var body = "Hello world";
 
+			var setup = new SmtpSetup
+			{
+				Host = host,
+				Port = port,
+				Credentials = credentials
+			};
+
 			// act
-			var smtp = new SmtpConnector(host, port, credentials);
+			var smtp = new SmtpConnector(setup);
 			var (total, success, failed) = smtp
 				.NewMessage(sender, sender, subject, body)
-				.CarbonCopy(copy)
-				.BlindCarbonCopy(copy)
+				//.CarbonCopy(copy)
+				//.BlindCarbonCopy(copy)
 				.HighPriority()
 				.Attach(new FileInfo("App_Data/demo.csv"))
 				.Send();


### PR DESCRIPTION
Hi @tripoder,

here again a feature update for you to review.
* The recent features are all merged.
* The main things to review within this PR are:
  * Introducion of [SmtpSetup](https://github.com/telescope-dotnet/telescope/blob/dev-smtp-setup/src/TeleScope.Connectors.Smtp/SmtpSetup.cs)
  * The [SmtpConnector](https://github.com/telescope-dotnet/telescope/blob/dev-smtp-setup/src/TeleScope.Connectors.Smtp/SmtpConnector.cs) is updated as follows
    * a new constructor that consumes the setup
    * Calling [NewMessage](https://github.com/telescope-dotnet/telescope/blob/dev-smtp-setup/src/TeleScope.Connectors.Smtp/SmtpConnector.cs#L136) is overloaded so this doesn't enforce sender and receiver, which is  given by the setup already. 
    * Validation of email address strings, see [here](https://github.com/telescope-dotnet/telescope/blob/dev-smtp-setup/src/TeleScope.Connectors.Smtp/SmtpConnector.cs#L341).
    * Different exception handlings and API documentations updated

Best regards, :neckbeard: 